### PR TITLE
Fix thread safety of the DriverConfigTemplate class

### DIFF
--- a/auto-sdk-java-cucumber/src/main/java/com/applause/auto/cucumber/plugins/ApplauseFrameworkPlugin.java
+++ b/auto-sdk-java-cucumber/src/main/java/com/applause/auto/cucumber/plugins/ApplauseFrameworkPlugin.java
@@ -150,8 +150,7 @@ public class ApplauseFrameworkPlugin implements ConcurrentEventListener {
     // For every driver that we are aware of at this time, check to see if we might need an app for
     // any of them
     for (var driver : expectedDrivers) {
-      final var expectedDriverCaps =
-          ContextManager.INSTANCE.lookupDriver(driver).getCurrentCapabilities();
+      final var expectedDriverCaps = ContextManager.INSTANCE.lookupDriver(driver).evaluate();
       if (!expectedDriverCaps.getApplauseOptions().isMobileNative()) {
         continue;
       }

--- a/auto-sdk-java-framework/src/main/java/com/applause/auto/framework/DriverBuilder.java
+++ b/auto-sdk-java-framework/src/main/java/com/applause/auto/framework/DriverBuilder.java
@@ -77,7 +77,7 @@ public class DriverBuilder {
    */
   public static DriverBuilder fromTemplate(final @NonNull DriverConfigTemplate template)
       throws BadJsonFormatException {
-    return new DriverBuilder(template.reProcess().getCurrentCapabilities());
+    return new DriverBuilder(template.evaluate());
   }
 
   /**

--- a/auto-sdk-java-framework/src/test/java/com/applause/auto/framework/templates/DriverConfigTemplateTest.java
+++ b/auto-sdk-java-framework/src/test/java/com/applause/auto/framework/templates/DriverConfigTemplateTest.java
@@ -1,0 +1,105 @@
+/*
+ *
+ * Copyright © 2024 Applause App Quality, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.applause.auto.framework.templates;
+
+import com.applause.auto.framework.DriverBuilder;
+import com.applause.auto.framework.json.BadJsonFormatException;
+import com.applause.auto.framework.selenium.ApplauseCapabilitiesConstants;
+import com.applause.auto.framework.selenium.EnhancedCapabilities;
+import com.applause.auto.templates.TemplateManager;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import lombok.SneakyThrows;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.MutableCapabilities;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DriverConfigTemplateTest {
+
+  @SuppressWarnings("unchecked")
+  @SneakyThrows
+  @Test
+  public void test() {
+    final var t =
+        TemplateManager.generateTemplate(
+            """
+                {
+                    \"applause:options\": {
+                        \"runName\": \"runName\",
+                        \"factoryKey\": \"factoryKey\",
+                        \"other\": 123
+                    }
+                }
+                """);
+    DriverConfigTemplate template = new DriverConfigTemplate(t);
+    template.refresh();
+    List<CompletableFuture<EnhancedCapabilities>> futures = new ArrayList<>();
+    for (int i = 0; i < 10000; i++) {
+      futures.add(
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  return DriverBuilder.fromTemplate(template)
+                      .overrideCaps(
+                          caps -> {
+                            MutableCapabilities result = new MutableCapabilities(caps);
+                            Map<String, Object> applauseOptions =
+                                Optional.ofNullable(
+                                        result.getCapability(
+                                            ApplauseCapabilitiesConstants.APPLAUSE_OPTIONS))
+                                    .map(
+                                        options -> {
+                                          if (options instanceof Capabilities) {
+                                            return ((Capabilities) options).asMap();
+                                          }
+                                          if (options instanceof Map) {
+                                            return (Map<String, Object>) options;
+                                          }
+                                          return null;
+                                        })
+                                    .orElseGet(HashMap::new);
+                            applauseOptions.put(ApplauseCapabilitiesConstants.API_KEY, "apiKey");
+                            applauseOptions.put(
+                                ApplauseCapabilitiesConstants.RUN_NAME, "providerRubName");
+                            applauseOptions.put(ApplauseCapabilitiesConstants.PRODUCT_ID, "123");
+                            result.setCapability(
+                                ApplauseCapabilitiesConstants.APPLAUSE_OPTIONS, applauseOptions);
+                            return result;
+                          })
+                      .getCaps();
+                } catch (BadJsonFormatException e) {
+                  return null;
+                }
+              }));
+    }
+    Assert.assertEquals(
+        futures.stream()
+            .map(CompletableFuture::join)
+            .filter(Objects::nonNull)
+            .map(c -> c.getApplauseOptions().getCapability("productId"))
+            .filter(Objects::isNull)
+            .count(),
+        0);
+  }
+}

--- a/auto-sdk-java-testng/src/main/java/com/applause/auto/testng/listeners/FrameworkConfigurationListener.java
+++ b/auto-sdk-java-testng/src/main/java/com/applause/auto/testng/listeners/FrameworkConfigurationListener.java
@@ -147,8 +147,7 @@ public class FrameworkConfigurationListener implements ISuiteListener {
     // For every driver that we are aware of at this time, check to see if we might need an app for
     // any of them
     for (var driver : expectedDrivers) {
-      final var expectedDriverCaps =
-          ContextManager.INSTANCE.lookupDriver(driver).getCurrentCapabilities();
+      final var expectedDriverCaps = ContextManager.INSTANCE.lookupDriver(driver).evaluate();
       if (!expectedDriverCaps.getApplauseOptions().isMobileNative()) {
         continue;
       }

--- a/pom.xml
+++ b/pom.xml
@@ -227,10 +227,10 @@
         <artifactId>javax.ws.rs-api</artifactId>
         <version>${javax.ws.rs-api.version}</version>
       </dependency>
-      <dependency>    
-        <groupId>com.sun.mail</groupId>    
-        <artifactId>jakarta.mail</artifactId>    
-        <version>2.0.1</version> 
+      <dependency>
+        <groupId>com.sun.mail</groupId>
+        <artifactId>jakarta.mail</artifactId>
+        <version>2.0.1</version>
       </dependency>
       <dependency>
         <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
### What changed?
A single DriverConfigTemplate class is created for a capability template file. When running multi-threaded, we could run into a case where a template is reevaluated by multiple threads, and they all access the same instance of the EnhancedCapabilities class. When running a series of CapabilityOverrider functions, we risk one thread corrupting the capabilities of another thread. Adding a synchronized block around all DriverConfigTemplate functions will ensure that each thread gets its own copy of the EnhancedCapabilities.
