### PR TITLE
Fix reverse dns checks

### DIFF
--- a/auto-sdk-java-config/src/main/java/com/applause/auto/config/SdkConfigBean.java
+++ b/auto-sdk-java-config/src/main/java/com/applause/auto/config/SdkConfigBean.java
@@ -202,4 +202,12 @@ public interface SdkConfigBean extends Config {
    */
   @DefaultValue("false")
   boolean noReverseDnsCheck();
+
+  /**
+   * Toggles bypassing configuration errors
+   *
+   * @return boolean enabled/disabled
+   */
+  @DefaultValue("false")
+  boolean bypassConfigurationErrors();
 }

--- a/auto-sdk-java-framework/src/main/java/com/applause/auto/framework/ApplauseFramework.java
+++ b/auto-sdk-java-framework/src/main/java/com/applause/auto/framework/ApplauseFramework.java
@@ -328,17 +328,20 @@ public enum ApplauseFramework {
     if (path.charAt(0) == '/') {
       path = path.substring(1);
     }
-    return this.setDriverManager(
-        new RemoteDriverManager(
-            new HttpUrl.Builder()
-                .scheme(seleniumGridUrl.getProtocol())
-                .addPathSegments(path)
-                .host(seleniumGridUrl.getHost())
-                .port(seleniumGridUrl.getPort())
-                .username(username)
-                .password(password)
-                .build()
-                .url()));
+    final var httpUrlBuilder =
+        new HttpUrl.Builder()
+            .scheme(seleniumGridUrl.getProtocol())
+            .addPathSegments(path)
+            .host(seleniumGridUrl.getHost())
+            .username(username)
+            .password(password);
+
+    // If the port is set, add it to the URL
+    // Otherwise, the default port will be used
+    if (seleniumGridUrl.getPort() != -1) {
+      httpUrlBuilder.port(seleniumGridUrl.getPort());
+    }
+    return this.setDriverManager(new RemoteDriverManager(httpUrlBuilder.build().url()));
   }
 
   /**


### PR DESCRIPTION
### What changed?
Fixes some url validation logic:
- Reverse DNS check was not working behind a firewall, the flag to turn off the heck was not working
- Add flag to have validation not throw an error
- Allow selenium grid url to not have port specified
