### PR TITLE
Generalize BrowserControl and DeviceControl to use UIElement instead of BaseElement

### DIFF
--- a/auto-sdk-java-helpers/src/main/java/com/applause/auto/helpers/control/BrowserControl.java
+++ b/auto-sdk-java-helpers/src/main/java/com/applause/auto/helpers/control/BrowserControl.java
@@ -19,7 +19,7 @@ package com.applause.auto.helpers.control;
 
 import com.applause.auto.context.IPageObjectContext;
 import com.applause.auto.context.IPageObjectExtension;
-import com.applause.auto.pageobjectmodel.base.BaseElement;
+import com.applause.auto.pageobjectmodel.base.UIElement;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URL;
@@ -74,7 +74,7 @@ public class BrowserControl implements IPageObjectExtension {
    *
    * @param element the element on which the mouse down will be performed
    */
-  private void mouseDown(final BaseElement element) {
+  private void mouseDown(final UIElement element) {
     getExecutor()
         .executeScript(
             getBrowserActionsScript() + "dispatchDownEvent(arguments[0]);",
@@ -88,7 +88,7 @@ public class BrowserControl implements IPageObjectExtension {
    * @param xOffset the x offset
    * @param yOffset the y offset
    */
-  private void mouseUp(final BaseElement element, final int xOffset, final int yOffset) {
+  private void mouseUp(final UIElement element, final int xOffset, final int yOffset) {
     getExecutor()
         .executeScript(
             getBrowserActionsScript()
@@ -104,7 +104,7 @@ public class BrowserControl implements IPageObjectExtension {
    *
    * @param element the element on which the mouse up will be performed
    */
-  private void mouseUp(final BaseElement element) {
+  private void mouseUp(final UIElement element) {
     mouseUp(element, 0, 0);
   }
 
@@ -116,7 +116,7 @@ public class BrowserControl implements IPageObjectExtension {
    * @param xOffset the x offset
    * @param yOffset the y offset
    */
-  private void mouseMove(final BaseElement element, final int xOffset, final int yOffset) {
+  private void mouseMove(final UIElement element, final int xOffset, final int yOffset) {
     getExecutor()
         .executeScript(
             getBrowserActionsScript()
@@ -132,7 +132,7 @@ public class BrowserControl implements IPageObjectExtension {
    *
    * @param element the target element to perform the action on.
    */
-  public void jsClick(final BaseElement element) {
+  public void jsClick(final UIElement element) {
     logger.debug("Performing a native click.");
     getExecutor().executeScript("arguments[0].click();", element.getUnderlyingWebElement());
   }
@@ -142,7 +142,7 @@ public class BrowserControl implements IPageObjectExtension {
    *
    * @param element the target element to perform the action on.
    */
-  public void click(final BaseElement element) {
+  public void click(final UIElement element) {
     mouseDown(element);
     mouseUp(element);
   }
@@ -153,7 +153,7 @@ public class BrowserControl implements IPageObjectExtension {
    * @param element the target element to perform the action on.
    * @param millis the time (in milliseconds) to simulate the hold for.
    */
-  public void clickAndHold(final BaseElement element, final long millis) {
+  public void clickAndHold(final UIElement element, final long millis) {
     mouseDown(element);
     sleep(millis);
     mouseUp(element);
@@ -164,7 +164,7 @@ public class BrowserControl implements IPageObjectExtension {
    *
    * @param element the target element to perform the action on.
    */
-  public void hoverOverElement(final BaseElement element) {
+  public void hoverOverElement(final UIElement element) {
     Dimension size = element.getUnderlyingWebElement().getSize();
     mouseMove(element, size.getWidth() / 2, size.getHeight() / 2);
   }
@@ -176,7 +176,7 @@ public class BrowserControl implements IPageObjectExtension {
    * @param xOffset the x-coordinate offset to move the element to.
    * @param yOffset the y-coordinate offset to move the element to.
    */
-  public void dragAndDrop(final BaseElement element, final int xOffset, final int yOffset) {
+  public void dragAndDrop(final UIElement element, final int xOffset, final int yOffset) {
     mouseDown(element);
     mouseMove(element, xOffset, yOffset);
     mouseUp(element, xOffset, yOffset);

--- a/auto-sdk-java-helpers/src/main/java/com/applause/auto/helpers/control/DeviceControl.java
+++ b/auto-sdk-java-helpers/src/main/java/com/applause/auto/helpers/control/DeviceControl.java
@@ -20,8 +20,8 @@ package com.applause.auto.helpers.control;
 import com.applause.auto.context.IPageObjectContext;
 import com.applause.auto.context.IPageObjectExtension;
 import com.applause.auto.data.enums.SwipeDirection;
-import com.applause.auto.pageobjectmodel.base.BaseElement;
 import com.applause.auto.pageobjectmodel.base.LocatedBy;
+import com.applause.auto.pageobjectmodel.base.UIElement;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.android.AndroidDriver;
@@ -354,14 +354,14 @@ public class DeviceControl implements IPageObjectExtension {
   /**
    * Tap on an element's position, offset from the top left of the element by pixel coordinates.
    *
-   * @param element the BaseElement to tap on
+   * @param element the UIElement to tap on
    * @param x horizontal pixel offset from the top left corner of the element
    * @param y vertical pixel offset from the top left corner of the element
    * @throws InvalidArgumentException if offset X or Y exceeds the size of the element.
    */
-  public void tapElementCoordinates(final BaseElement element, final int x, final int y) {
-    Point anchor = element.getLocation();
-    Dimension size = element.getDimension();
+  public void tapElementCoordinates(final UIElement element, final int x, final int y) {
+    Point anchor = element.getUnderlyingWebElement().getLocation();
+    Dimension size = element.getUnderlyingWebElement().getSize();
 
     logger.debug(
         String.format(
@@ -385,10 +385,10 @@ public class DeviceControl implements IPageObjectExtension {
   /**
    * Tap in the center of an element's position.
    *
-   * @param element the BaseElement to tap on
+   * @param element the UIElement to tap on
    */
-  public void tapElementCenter(final BaseElement element) {
-    Dimension size = element.getDimension();
+  public void tapElementCenter(final UIElement element) {
+    Dimension size = element.getUnderlyingWebElement().getSize();
     int x = size.width / 2;
     int y = size.height / 2;
     tapElementCoordinates(element, x, y);
@@ -424,16 +424,16 @@ public class DeviceControl implements IPageObjectExtension {
    * Taps on an element's position, offset from the top left of the element by pixel coordinates,
    * and holds it for a specified duration.
    *
-   * @param element the BaseElement to tap on
+   * @param element the UIElement to tap on
    * @param x horizontal pixel offset from the top left corner of the element
    * @param y vertical pixel offset from the top left corner of the element
    * @param millis duration to hold the tap, in milliseconds
    * @throws InvalidArgumentException if offset X or Y exceeds the size of the element.
    */
   public void pressAndHoldElementCoordinates(
-      final BaseElement element, final int x, final int y, final long millis) {
-    Point anchor = element.getLocation();
-    Dimension size = element.getDimension();
+      final UIElement element, final int x, final int y, final long millis) {
+    Point anchor = element.getUnderlyingWebElement().getLocation();
+    Dimension size = element.getUnderlyingWebElement().getSize();
 
     logger.debug(
         String.format(
@@ -457,12 +457,12 @@ public class DeviceControl implements IPageObjectExtension {
   /**
    * Taps in the center of an element and holds it for a specified duration.
    *
-   * @param element the BaseElement to tap on
+   * @param element the UIElement to tap on
    * @param millis duration to hold the tap, in milliseconds
    * @throws InvalidArgumentException if offset X or Y exceeds the size of the element.
    */
-  public void pressAndHoldElementCenter(final BaseElement element, final long millis) {
-    Dimension size = element.getDimension();
+  public void pressAndHoldElementCenter(final UIElement element, final long millis) {
+    Dimension size = element.getUnderlyingWebElement().getSize();
     int x = size.width / 2;
     int y = size.height / 2;
     pressAndHoldElementCoordinates(element, x, y, millis);
@@ -522,14 +522,14 @@ public class DeviceControl implements IPageObjectExtension {
    * @param millis duration over which the swipe is performed, in milliseconds
    */
   public void swipeAcrossElementCoordinates(
-      final BaseElement element,
+      final UIElement element,
       final int startX,
       final int startY,
       final int endX,
       final int endY,
       final long millis) {
-    Point anchor = element.getLocation();
-    Dimension size = element.getDimension();
+    Point anchor = element.getUnderlyingWebElement().getLocation();
+    Dimension size = element.getUnderlyingWebElement().getSize();
 
     logger.debug(
         String.format(
@@ -571,9 +571,9 @@ public class DeviceControl implements IPageObjectExtension {
    * @param direction a SwipeDirection object indicating which direction to swipe.
    */
   public void swipeAcrossElementWithDirection(
-      final BaseElement element, final SwipeDirection direction) {
-    Point anchor = element.getLocation();
-    Dimension size = element.getDimension();
+      final UIElement element, final SwipeDirection direction) {
+    Point anchor = element.getUnderlyingWebElement().getLocation();
+    Dimension size = element.getUnderlyingWebElement().getSize();
 
     logger.debug(
         String.format(


### PR DESCRIPTION
### What changed?
BrowserControl and DeviceControl were coupled to the BaseElement implementation of UIElement. This PR refactors some of the helpers to allow for any UIElement implementation to be passed in.
