### PR TITLE
Fix initializing an implementation of an abstract base component

### DIFF
--- a/auto-sdk-java-framework/src/test/java/com/applause/auto/framework/selenium/EnhancedCapabilitiesTest.java
+++ b/auto-sdk-java-framework/src/test/java/com/applause/auto/framework/selenium/EnhancedCapabilitiesTest.java
@@ -18,6 +18,7 @@
 package com.applause.auto.framework.selenium;
 
 import com.applause.auto.data.enums.DriverType;
+import com.applause.auto.data.enums.Platform;
 import com.applause.auto.framework.json.BadJsonFormatException;
 import java.io.File;
 import java.io.IOException;
@@ -141,6 +142,7 @@ public class EnhancedCapabilitiesTest {
     // Check to see that we have NOT converted Longs to Doubles as out-of-the-box Gson done
     Assert.assertEquals("600", appCap.getCapability("commandTimeout").toString());
     Assert.assertEquals(DriverType.MOBILENATIVE, appCap.getApplauseOptions().getDriverType());
+    Assert.assertEquals(Platform.MOBILE_IOS_PHONE, appCap.getApplauseOptions().getFactoryKey());
 
     // We have an array in the class.  Check that
     final Map<String, Object> shouldBeMap =

--- a/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/annotation/PlatformFilter.java
+++ b/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/annotation/PlatformFilter.java
@@ -54,11 +54,9 @@ public final class PlatformFilter {
     while (currentPlatform != null) {
       final var setPlatform = currentPlatform;
       final var matches =
-          annotations.stream()
-              .filter(a -> platformLookup.apply(a) == setPlatform)
-              .collect(Collectors.toList());
+          annotations.stream().filter(a -> platformLookup.apply(a) == setPlatform).toList();
       if (!matches.isEmpty()) {
-        return new ResultSet<>(currentPlatform, matches);
+        return new ResultSet<>(setPlatform, matches);
       }
       currentPlatform = currentPlatform.getFallback();
     }

--- a/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/builder/BaseComponentBuilder.java
+++ b/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/builder/BaseComponentBuilder.java
@@ -57,7 +57,7 @@ public class BaseComponentBuilder<T extends BaseComponent> extends UiElementBuil
         TypeToken.of(
             ImplementationHelper.getImplementation(
                 (Class<T>) typeToken.getRawType(), context.getPlatform()));
-    if (Modifier.isAbstract(typeToken.getRawType().getModifiers())) {
+    if (Modifier.isAbstract(this.typeToken.getRawType().getModifiers())) {
       throw new UnsupportedOperationException(
           String.format(
               "BaseComponentBuilder cannot create an instance of an abstract BaseComponent. Class [%s].",

--- a/auto-sdk-java-page-object/src/test/java/com/applause/auto/pageobjectmodel/annotation/AbstractParentImplementation.java
+++ b/auto-sdk-java-page-object/src/test/java/com/applause/auto/pageobjectmodel/annotation/AbstractParentImplementation.java
@@ -1,0 +1,48 @@
+/*
+ *
+ * Copyright © 2025 Applause App Quality, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.applause.auto.pageobjectmodel.annotation;
+
+import com.applause.auto.data.enums.Platform;
+import com.applause.auto.pageobjectmodel.base.BaseComponent;
+import lombok.NoArgsConstructor;
+
+@Implementation(is = AbstractParentImplementation.class, on = Platform.DEFAULT)
+@Implementation(is = ChildAndroidImplementation.class, on = Platform.MOBILE_ANDROID)
+@Implementation(is = ChildIOSImplementation.class, on = Platform.MOBILE_IOS)
+public abstract class AbstractParentImplementation extends BaseComponent {
+
+  public abstract String getImplementationName();
+}
+
+@NoArgsConstructor
+class ChildAndroidImplementation extends AbstractParentImplementation {
+
+  @Override
+  public String getImplementationName() {
+    return "AndroidImplementation";
+  }
+}
+
+@NoArgsConstructor
+class ChildIOSImplementation extends AbstractParentImplementation {
+
+  @Override
+  public String getImplementationName() {
+    return "IOSImplementation";
+  }
+}

--- a/auto-sdk-java-page-object/src/test/java/com/applause/auto/pageobjectmodel/annotation/ImplementationHelperTest.java
+++ b/auto-sdk-java-page-object/src/test/java/com/applause/auto/pageobjectmodel/annotation/ImplementationHelperTest.java
@@ -1,0 +1,44 @@
+/*
+ *
+ * Copyright © 2025 Applause App Quality, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.applause.auto.pageobjectmodel.annotation;
+
+import static org.testng.Assert.*;
+
+import com.applause.auto.data.enums.Platform;
+import org.testng.annotations.Test;
+
+public class ImplementationHelperTest {
+
+  @Test
+  public void testAbstractParentImplementations() {
+
+    final var androidClass =
+        ImplementationHelper.getImplementation(
+            AbstractParentImplementation.class, Platform.MOBILE_ANDROID);
+    assertEquals(androidClass.getSimpleName(), "ChildAndroidImplementation");
+
+    final var iosClass =
+        ImplementationHelper.getImplementation(
+            AbstractParentImplementation.class, Platform.MOBILE_IOS);
+    assertEquals(iosClass.getSimpleName(), "ChildIOSImplementation");
+
+    final var webClass =
+        ImplementationHelper.getImplementation(AbstractParentImplementation.class, Platform.WEB);
+    assertEquals(webClass.getSimpleName(), "AbstractParentImplementation");
+  }
+}

--- a/auto-sdk-java-page-object/src/test/java/com/applause/auto/pageobjectmodel/annotation/PlatformFilterTest.java
+++ b/auto-sdk-java-page-object/src/test/java/com/applause/auto/pageobjectmodel/annotation/PlatformFilterTest.java
@@ -1,0 +1,169 @@
+/*
+ *
+ * Copyright © 2025 Applause App Quality, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.applause.auto.pageobjectmodel.annotation;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.applause.auto.data.enums.Platform;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.List;
+import org.testng.annotations.Test;
+
+public class PlatformFilterTest {
+
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface TestAnnotations {
+    TestAnnotation[] value();
+  }
+
+  @Repeatable(TestAnnotations.class)
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface TestAnnotation {
+    Platform platform();
+  }
+
+  @TestAnnotation(platform = Platform.MOBILE_ANDROID)
+  private static class AnnotatedClass {}
+
+  @TestAnnotation(platform = Platform.MOBILE_IOS)
+  private static class AnotherAnnotatedClass {}
+
+  @TestAnnotation(platform = Platform.MOBILE_ANDROID)
+  @TestAnnotation(platform = Platform.MOBILE_IOS)
+  private static class DoubleAnnotatedClass {}
+
+  @TestAnnotation(platform = Platform.MOBILE_ANDROID)
+  @TestAnnotation(platform = Platform.MOBILE_ANDROID)
+  private static class DoubleIdenticalAnnotatedClass {}
+
+  @TestAnnotation(platform = Platform.DEFAULT)
+  @TestAnnotation(platform = Platform.MOBILE_ANDROID)
+  @TestAnnotation(platform = Platform.MOBILE_ANDROID)
+  private static class IdenticalAndDefaultAnnotatedClass {}
+
+  @Test
+  public void testFilterByPlatform() {
+    var annotations =
+        List.of(
+            AnnotatedClass.class.getAnnotation(TestAnnotation.class),
+            AnotherAnnotatedClass.class.getAnnotation(TestAnnotation.class));
+
+    var result =
+        PlatformFilter.filterByPlatform(
+            annotations, Platform.MOBILE_ANDROID, TestAnnotation::platform);
+    assertEquals(result.platform(), Platform.MOBILE_ANDROID);
+    assertEquals(result.matches().size(), 1);
+    assertEquals(result.matches().iterator().next().platform(), Platform.MOBILE_ANDROID);
+  }
+
+  @Test
+  public void testLookupAnnotations() {
+    var result =
+        PlatformFilter.lookupAnnotations(
+            Platform.MOBILE_ANDROID,
+            AnnotatedClass.class,
+            TestAnnotation.class,
+            TestAnnotation::platform);
+    assertEquals(result.platform(), Platform.MOBILE_ANDROID);
+    assertEquals(result.matches().size(), 1);
+    assertEquals(result.matches().iterator().next().platform(), Platform.MOBILE_ANDROID);
+  }
+
+  @Test
+  public void testLookupAnnotationsWithNoMatch() {
+    var result =
+        PlatformFilter.lookupAnnotations(
+            Platform.WEB, AnnotatedClass.class, TestAnnotation.class, TestAnnotation::platform);
+    assertEquals(result.platform(), Platform.DEFAULT);
+    assertTrue(result.matches().isEmpty());
+  }
+
+  @Test
+  public void testFilterByPlatformWithMultipleAnnotations() {
+    var annotations =
+        List.of(DoubleAnnotatedClass.class.getAnnotationsByType(TestAnnotation.class));
+
+    var result =
+        PlatformFilter.filterByPlatform(
+            annotations, Platform.MOBILE_ANDROID, TestAnnotation::platform);
+    assertEquals(result.platform(), Platform.MOBILE_ANDROID);
+    assertEquals(result.matches().size(), 1);
+    assertEquals(result.matches().iterator().next().platform(), Platform.MOBILE_ANDROID);
+  }
+
+  @Test
+  public void testLookupAnnotationsWithAggregateAnnotation() {
+    var result =
+        PlatformFilter.lookupAnnotations(
+            Platform.MOBILE_ANDROID,
+            DoubleAnnotatedClass.class,
+            TestAnnotations.class,
+            TestAnnotation.class,
+            TestAnnotations::value,
+            TestAnnotation::platform);
+    assertEquals(result.platform(), Platform.MOBILE_ANDROID);
+    assertEquals(result.matches().size(), 1);
+    assertEquals(result.matches().iterator().next().platform(), Platform.MOBILE_ANDROID);
+  }
+
+  @Test
+  public void testFilterByPlatformWithSamePlatformAnnotations() {
+    var annotations =
+        List.of(DoubleIdenticalAnnotatedClass.class.getAnnotationsByType(TestAnnotation.class));
+
+    var result =
+        PlatformFilter.filterByPlatform(
+            annotations, Platform.MOBILE_ANDROID, TestAnnotation::platform);
+    assertEquals(result.platform(), Platform.MOBILE_ANDROID);
+    assertEquals(result.matches().size(), 2);
+    assertEquals(result.matches().iterator().next().platform(), Platform.MOBILE_ANDROID);
+  }
+
+  @Test
+  public void testLookupAnnotationsWithAggregateSamePlatformAnnotations() {
+    var result =
+        PlatformFilter.lookupAnnotations(
+            Platform.MOBILE_ANDROID,
+            DoubleIdenticalAnnotatedClass.class,
+            TestAnnotations.class,
+            TestAnnotation.class,
+            TestAnnotations::value,
+            TestAnnotation::platform);
+    assertEquals(result.platform(), Platform.MOBILE_ANDROID);
+    assertEquals(result.matches().size(), 2);
+    assertEquals(result.matches().iterator().next().platform(), Platform.MOBILE_ANDROID);
+  }
+
+  @Test
+  public void testLookupAnnotationsWithAggregateSamePlatformWithDefaultAnnotations() {
+    var result =
+        PlatformFilter.lookupAnnotations(
+            Platform.MOBILE_ANDROID,
+            IdenticalAndDefaultAnnotatedClass.class,
+            TestAnnotations.class,
+            TestAnnotation.class,
+            TestAnnotations::value,
+            TestAnnotation::platform);
+    assertEquals(result.platform(), Platform.MOBILE_ANDROID);
+    assertEquals(result.matches().size(), 2);
+    assertEquals(result.matches().iterator().next().platform(), Platform.MOBILE_ANDROID);
+  }
+}


### PR DESCRIPTION
### What changed?
The SDK is unable to initialize an abstract BaseComponent with a valid, non-abstract, Implementation. Something like the following example:

```java
@Implementation(is = ImplementationComponent.class, on = Platform.WEB)
// There could also be an implementation on other platforms
public abstract SomeComponent extends BaseComponent {
    // Some locators
    
    // Some abstract methods
}

public ImplementationComponent extends SomeComponent {
    // Implementation of the above
}
```

This was possible in version 5.x of the SDK. The issue is with the abstract check within the BaseComponentBuilder. It was being performed on the class being passed in to the BaseComponentBuilder instead of the implementation class that we look up from the annotation. 