### PR TITLE
Fix build pagination iteration parameters

### DIFF
--- a/auto-sdk-java-integrations/src/main/java/com/applause/auto/helpers/AutoBuildHelper.java
+++ b/auto-sdk-java-integrations/src/main/java/com/applause/auto/helpers/AutoBuildHelper.java
@@ -40,7 +40,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import lombok.AccessLevel;
 import lombok.NonNull;
+import lombok.Setter;
 import lombok.SneakyThrows;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -64,7 +66,9 @@ public final class AutoBuildHelper {
           .withMaxRetries(MAX_RETIES)
           .build();
   private static final Proxy httpProxy = ApplauseConfigHelper.getHttpProxy();
-  private static final ApplausePublicApi publicApiClient =
+
+  @Setter(value = AccessLevel.PACKAGE)
+  private static ApplausePublicApi publicApiClient =
       ApplausePublicApiClient.getClient(
           ApplauseEnvironmentConfigurationManager.INSTANCE.get().applausePublicApiUrl(),
           ApplauseEnvironmentConfigurationManager.INSTANCE.get().apiKey(),
@@ -218,12 +222,12 @@ public final class AutoBuildHelper {
    *
    * @return List of BuildDto
    */
-  private static List<ProductVersionDetailsDto> getAllBuilds() {
+  static List<ProductVersionDetailsDto> getAllBuilds() {
     List<ProductVersionDetailsDto> builds = new ArrayList<>();
     final var firstPage = getBuildPage(1L, 100L, "desc");
     builds.addAll(firstPage.content());
-    for (long i = 2; i < firstPage.totalPages(); i++) {
-      final var page = getBuildPage(i, 100L, "desc");
+    for (long i = 2; i <= firstPage.totalPages(); i++) {
+      final var page = getBuildPage(i, 100L, "createDate,desc");
       builds.addAll(page.content());
     }
     return builds;

--- a/auto-sdk-java-integrations/src/test/java/com/applause/auto/helpers/AutoBuildHelperTest.java
+++ b/auto-sdk-java-integrations/src/test/java/com/applause/auto/helpers/AutoBuildHelperTest.java
@@ -17,16 +17,29 @@
  */
 package com.applause.auto.helpers;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.applause.auto.config.ApplauseEnvironmentConfigurationManager;
 import com.applause.auto.config.EnvironmentConfigurationManager;
 import com.applause.auto.framework.selenium.EnhancedCapabilities;
+import com.applause.auto.util.applausepublicapi.ApplausePublicApi;
+import com.applause.auto.util.applausepublicapi.api.BuildApi;
+import com.applause.auto.util.applausepublicapi.dto.AttachmentWithHashesDto;
+import com.applause.auto.util.applausepublicapi.dto.PageProductVersionDetailsDto;
+import com.applause.auto.util.applausepublicapi.dto.ProductVersionDetailsDto;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import retrofit2.Response;
 
 public class AutoBuildHelperTest {
+
   @Test
   public void testGetApp() {
     // test null input with no EnvironmentConfig
@@ -54,5 +67,92 @@ public class AutoBuildHelperTest {
         "preferred-app",
         AutoBuildHelper.getApp(caps),
         "with appCaps, return 'preferred-app' from Bean");
+  }
+
+  @Test
+  public void testGetAllBuilds() {
+    // Mock the response from the public API client
+    ApplauseEnvironmentConfigurationManager.INSTANCE.override(Map.of("productId", "1"));
+    BuildApi mockBuildsApi = mock(BuildApi.class);
+    ApplausePublicApi mockApiClient = mock(ApplausePublicApi.class);
+    AttachmentWithHashesDto mockAttachment = mock(AttachmentWithHashesDto.class);
+    PageProductVersionDetailsDto mockPage = mock(PageProductVersionDetailsDto.class);
+    ProductVersionDetailsDto mockVersion = mock(ProductVersionDetailsDto.class);
+
+    // Set up the mock responses
+    when(mockAttachment.url()).thenReturn("http://mock.url");
+    when(mockVersion.attachments()).thenReturn(List.of(mockAttachment));
+    when(mockPage.content()).thenReturn(List.of(mockVersion));
+    when(mockPage.totalPages()).thenReturn(1L);
+    when(mockBuildsApi.getBuilds(anyLong(), anyLong(), anyLong(), anyString()))
+        .thenReturn(CompletableFuture.completedFuture(Response.success(mockPage)));
+    when(mockApiClient.builds()).thenReturn(mockBuildsApi);
+
+    // Inject the mock client into the AutoBuildHelper
+    AutoBuildHelper.setPublicApiClient(mockApiClient);
+
+    // Call the method under test
+    List<ProductVersionDetailsDto> builds = AutoBuildHelper.getAllBuilds();
+
+    // Verify the results
+    Assert.assertNotNull(builds, "Builds list should not be null");
+    Assert.assertFalse(builds.isEmpty(), "Builds list should not be empty");
+    Assert.assertEquals(builds.size(), 1, "Builds list should contain one element");
+    Assert.assertEquals(builds.get(0), mockVersion, "Builds list should contain the mock version");
+  }
+
+  @Test
+  public void testGetAllBuildsWithMultiplePages() {
+    // Mock the response from the public API client
+    ApplauseEnvironmentConfigurationManager.INSTANCE.override(Map.of("productId", "1"));
+    BuildApi mockBuildsApi = mock(BuildApi.class);
+    ApplausePublicApi mockApiClient = mock(ApplausePublicApi.class);
+    AttachmentWithHashesDto mockAttachment = mock(AttachmentWithHashesDto.class);
+    PageProductVersionDetailsDto mockPage1 = mock(PageProductVersionDetailsDto.class);
+    PageProductVersionDetailsDto mockPage2 = mock(PageProductVersionDetailsDto.class);
+    PageProductVersionDetailsDto mockPage3 = mock(PageProductVersionDetailsDto.class);
+    ProductVersionDetailsDto mockVersion1 = mock(ProductVersionDetailsDto.class);
+    ProductVersionDetailsDto mockVersion2 = mock(ProductVersionDetailsDto.class);
+    ProductVersionDetailsDto mockVersion3 = mock(ProductVersionDetailsDto.class);
+
+    // Set up attachments for some of the versions
+    when(mockAttachment.url()).thenReturn("http://mock.url");
+    when(mockVersion1.attachments()).thenReturn(List.of(mockAttachment));
+    when(mockVersion3.attachments()).thenReturn(List.of(mockAttachment));
+
+    // Set up the mock responses for each page
+    when(mockPage1.content()).thenReturn(List.of(mockVersion1));
+    when(mockPage1.totalPages()).thenReturn(3L);
+    when(mockPage2.content()).thenReturn(List.of(mockVersion2));
+    when(mockPage2.totalPages()).thenReturn(3L);
+    when(mockPage3.content()).thenReturn(List.of(mockVersion3));
+    when(mockPage3.totalPages()).thenReturn(3L);
+
+    // Mock the API client to return the correct page based on the page number
+    when(mockBuildsApi.getBuilds(anyLong(), eq(1L), anyLong(), anyString()))
+        .thenReturn(CompletableFuture.completedFuture(Response.success(mockPage1)));
+    when(mockBuildsApi.getBuilds(anyLong(), eq(2L), anyLong(), anyString()))
+        .thenReturn(CompletableFuture.completedFuture(Response.success(mockPage2)));
+    when(mockBuildsApi.getBuilds(anyLong(), eq(3L), anyLong(), anyString()))
+        .thenReturn(CompletableFuture.completedFuture(Response.success(mockPage3)));
+
+    when(mockApiClient.builds()).thenReturn(mockBuildsApi);
+
+    // Inject the mock client into the AutoBuildHelper
+    AutoBuildHelper.setPublicApiClient(mockApiClient);
+
+    // Call the method under test
+    List<ProductVersionDetailsDto> builds = AutoBuildHelper.getAllBuilds();
+
+    // Verify the results
+    Assert.assertNotNull(builds, "Builds list should not be null");
+    Assert.assertFalse(builds.isEmpty(), "Builds list should not be empty");
+    Assert.assertEquals(builds.size(), 3, "Builds list should contain three elements");
+    Assert.assertEquals(
+        builds.get(0), mockVersion1, "First element should be the first mock version");
+    Assert.assertEquals(
+        builds.get(1), mockVersion2, "Second element should be the second mock version");
+    Assert.assertEquals(
+        builds.get(2), mockVersion3, "Third element should be the third mock version");
   }
 }


### PR DESCRIPTION
### What changed?
The `AutoBuilderHelper` handles communication with PublicApi for autodetecting the latest version of an app. To handle this, we need to handle the pagination of the public API responses to ensure that we get the latest build containing an attachment. 

Public API Pagination is 1 index, as opposed to 0 indexed, so we needed to extend out for loop to include the "totalPages" index, which would be the last page.

Additionally, we were not passing a field into the sort parameter, which caused us to get an unsorted response. This shouldn't affect the results, but we would rather receive the newest builds in earlier pages, in case we want to make this more efficient in the future.

I also added more unit tests to test this functionality to ensure that it does not break in future versions
