### PR TITLE
Fix support for app autodetection piped into app upload

### DIFF
--- a/auto-sdk-java-cucumber/src/main/java/com/applause/auto/cucumber/plugins/ApplauseFrameworkPlugin.java
+++ b/auto-sdk-java-cucumber/src/main/java/com/applause/auto/cucumber/plugins/ApplauseFrameworkPlugin.java
@@ -155,8 +155,8 @@ public class ApplauseFrameworkPlugin implements ConcurrentEventListener {
         continue;
       }
       if (!expectedDriverCaps.getCapabilityNames().contains("app")) {
-        ApplauseAppPushHelper.performApplicationPushIfNecessary();
         ApplauseAppPushHelper.autoDetectBuildIfNecessary();
+        ApplauseAppPushHelper.performApplicationPushIfNecessary();
       }
     }
   }

--- a/auto-sdk-java-framework/src/main/java/com/applause/auto/framework/json/GsonHelper.java
+++ b/auto-sdk-java-framework/src/main/java/com/applause/auto/framework/json/GsonHelper.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.NonNull;
-import okhttp3.MediaType;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
@@ -197,15 +196,6 @@ public final class GsonHelper {
     ResponseBody body = okHttpRsp.body();
     if (body == null) {
       throw new RuntimeException("Unable to parse response - null body");
-    }
-    // IF the context type is not passed back correctly, then default it to application json
-    MediaType contentAndMetaData =
-        Optional.ofNullable(body.contentType()).orElse(MediaType.get("application/json"));
-    if (!"json".equalsIgnoreCase(contentAndMetaData.subtype())) {
-      throw new RuntimeException(
-          String.format(
-              "Non JSON content: type=%s, subtype=%s",
-              contentAndMetaData.type(), contentAndMetaData.subtype()));
     }
     final String rawBody;
     try {

--- a/auto-sdk-java-framework/src/main/java/com/applause/auto/framework/selenium/apppush/AppPushHelper.java
+++ b/auto-sdk-java-framework/src/main/java/com/applause/auto/framework/selenium/apppush/AppPushHelper.java
@@ -36,6 +36,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.HttpMethod;
@@ -304,10 +305,10 @@ public final class AppPushHelper {
    */
   public static String pushProviderToPushAppClass(@NonNull final String pushProvider) {
     // Eventually we should externalize this
-    if ("BROWSERSTACK".equalsIgnoreCase(pushProvider)) {
+    if (pushProvider.toUpperCase(Locale.getDefault()).contains("BROWSERSTACK")) {
       return BrowserstackPusher.class.getCanonicalName();
     }
-    if ("SAUCELABS".equalsIgnoreCase(pushProvider)) {
+    if (pushProvider.toUpperCase(Locale.getDefault()).contains("SAUCELABS")) {
       return SauceLabsPusher.class.getCanonicalName();
     }
     throw new RuntimeException("Unable to map " + pushProvider + " to a concrete class");

--- a/auto-sdk-java-testng/src/main/java/com/applause/auto/testng/listeners/FrameworkConfigurationListener.java
+++ b/auto-sdk-java-testng/src/main/java/com/applause/auto/testng/listeners/FrameworkConfigurationListener.java
@@ -152,8 +152,8 @@ public class FrameworkConfigurationListener implements ISuiteListener {
         continue;
       }
       if (!expectedDriverCaps.getCapabilityNames().contains("app")) {
-        ApplauseAppPushHelper.performApplicationPushIfNecessary();
         ApplauseAppPushHelper.autoDetectBuildIfNecessary();
+        ApplauseAppPushHelper.performApplicationPushIfNecessary();
         break;
       }
     }


### PR DESCRIPTION
### What changed?
* Moves App AutoDetection before app upload
* Removes content type check for GSON Response Parsing (BrowserStack was sending back an HTML content-type)
* Fixes matching of App Push Provider to support longer Provider names (including "SauceLabs US West"/"SauceLabs EU Central")
* Adds SauceLabs support for pushing from a URL by downloading the app to a temp file
