### PR TITLE
Fix StaleElementReferenceException in locator chain

### DIFF
--- a/auto-sdk-java-helpers/src/main/java/com/applause/auto/helpers/control/BrowserControl.java
+++ b/auto-sdk-java-helpers/src/main/java/com/applause/auto/helpers/control/BrowserControl.java
@@ -172,7 +172,7 @@ public class BrowserControl implements IPageObjectExtension {
    * @param element the target element to perform the action on.
    */
   public void hoverOverElement(final UIElement element) {
-    Dimension size = element.getUnderlyingWebElement().getSize();
+    Dimension size = element.getLazyWebElement().getSize();
     mouseMove(element, size.getWidth() / 2, size.getHeight() / 2);
   }
 

--- a/auto-sdk-java-helpers/src/main/java/com/applause/auto/helpers/sync/UiConditions.java
+++ b/auto-sdk-java-helpers/src/main/java/com/applause/auto/helpers/sync/UiConditions.java
@@ -197,7 +197,7 @@ public final class UiConditions {
         withNoWait(
             uiElement,
             element -> {
-              String textValue = element.getUnderlyingWebElement().getText();
+              String textValue = element.getLazyWebElement().getText();
               return textValue != null && textValue.equals(text);
             });
   }
@@ -215,7 +215,7 @@ public final class UiConditions {
         withNoWait(
             uiElement,
             element -> {
-              String textValue = element.getUnderlyingWebElement().getText();
+              String textValue = element.getLazyWebElement().getText();
               return textValue != null && textValue.contains(substring);
             });
   }

--- a/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/base/BaseComponent.java
+++ b/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/base/BaseComponent.java
@@ -207,6 +207,16 @@ public abstract class BaseComponent implements UIElement {
   }
 
   @Override
+  public LazyWebElement getLazyWebElement() {
+    if (this.underlying == null) {
+      throw new UnsupportedOperationException(
+          "Cannot get underlying element for component [%s] with no underlying element"
+              .formatted(this.getClass().getSimpleName()));
+    }
+    return this.underlying;
+  }
+
+  @Override
   public WebElement getUnderlyingWebElement() {
     if (this.underlying == null) {
       throw new UnsupportedOperationException(

--- a/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/base/BaseElement.java
+++ b/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/base/BaseElement.java
@@ -146,6 +146,11 @@ public abstract class BaseElement implements UIElement {
   }
 
   @Override
+  public LazyWebElement getLazyWebElement() {
+    return this.underlying;
+  }
+
+  @Override
   public WebElement getUnderlyingWebElement() {
     return this.underlying.getUnderlyingWebElement();
   }

--- a/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/base/UIElement.java
+++ b/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/base/UIElement.java
@@ -19,6 +19,7 @@ package com.applause.auto.pageobjectmodel.base;
 
 import com.applause.auto.data.enums.SwipeDirection;
 import com.applause.auto.pageobjectmodel.elements.ContainerElement;
+import com.applause.auto.pageobjectmodel.factory.LazyWebElement;
 import com.applause.auto.pageobjectmodel.factory.Locator;
 import java.util.List;
 import org.openqa.selenium.By;
@@ -32,6 +33,7 @@ import org.openqa.selenium.WebElement;
  */
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public interface UIElement extends Locatable {
+
   /**
    * Gets a child UIElement of this UIElement. This can be either a subclass of BaseElement or
    * BaseComponent.
@@ -208,7 +210,17 @@ public interface UIElement extends Locatable {
   String getAttribute(String attribute);
 
   /**
-   * Gets the underlying web element
+   * Gets the underlying LazyWebElement
+   *
+   * @return The underlying LazyWebElement
+   */
+  LazyWebElement getLazyWebElement();
+
+  /**
+   * Gets the underlying web element. This is the actual selenium WebElement object that is being
+   * wrapped by the Applause Library. This is useful for when you need to interact with the
+   * WebElement directly. In most cases, you should consider using the getLazyWebElement() method
+   * instead, as the LazyWebElement can handle lazy loading and StaleElementRefereceExceptions.
    *
    * @return The underlying WebElement
    */

--- a/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/factory/LazyWebElement.java
+++ b/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/factory/LazyWebElement.java
@@ -213,6 +213,11 @@ public class LazyWebElement implements WebElement, UIElement {
   }
 
   @Override
+  public LazyWebElement getLazyWebElement() {
+    return this;
+  }
+
+  @Override
   public WebElement getUnderlyingWebElement() {
     return runLazily(() -> underlying);
   }

--- a/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/factory/LocatorChain.java
+++ b/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/factory/LocatorChain.java
@@ -118,13 +118,7 @@ public class LocatorChain {
     // If we have a parent
     var parent = this.chain.isEmpty() ? null : this.chain.getLast();
     if (parent != null) {
-      if (!parent.isInitialized()) {
-        parent.initialize();
-      }
-      var searchContext =
-          parent.getLocator().isShadowRoot()
-              ? parent.getShadowRoot()
-              : parent.getUnderlyingWebElement();
+      var searchContext = parent.getLocator().isShadowRoot() ? parent.getShadowRoot() : parent;
       return this.findElementInContext(
           searchContext, this.underlying.getLocator(), this.underlying.getFormatArgs());
     }
@@ -143,13 +137,7 @@ public class LocatorChain {
     // If we have a parent
     var parent = this.chain.isEmpty() ? null : this.chain.getLast();
     if (parent != null) {
-      if (!parent.isInitialized()) {
-        parent.initialize();
-      }
-      var searchContext =
-          parent.getLocator().isShadowRoot()
-              ? parent.getShadowRoot()
-              : parent.getUnderlyingWebElement();
+      var searchContext = parent.getLocator().isShadowRoot() ? parent.getShadowRoot() : parent;
       return this.findElementsInContext(
           searchContext, this.underlying.getLocator(), this.underlying.getFormatArgs());
     }


### PR DESCRIPTION
### What changed?
Switch the SearchContext in the LocatorChain to use our LazyWebElement in place of the WebElement from getUnderlyingWebElement(). This will allow us to catch the StaleElementReferenceException, reinitialize the parent, and retry locating the element.