### PR TITLE
Update app autodetection checks to look for appium:app property

### DIFF
--- a/auto-sdk-java-cucumber/src/main/java/com/applause/auto/cucumber/plugins/ApplauseFrameworkPlugin.java
+++ b/auto-sdk-java-cucumber/src/main/java/com/applause/auto/cucumber/plugins/ApplauseFrameworkPlugin.java
@@ -40,6 +40,7 @@ import com.applause.auto.integrations.TestCycleCloneUtil;
 import com.applause.auto.logging.LogOutputSingleton;
 import com.applause.auto.logging.ResultPropertyMap;
 import com.applause.auto.templates.TemplateManager;
+import com.google.api.client.util.Strings;
 import com.google.common.collect.Sets;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.cucumber.plugin.event.EventPublisher;
@@ -147,14 +148,20 @@ public class ApplauseFrameworkPlugin implements ConcurrentEventListener {
       return;
     }
 
-    // For every driver that we are aware of at this time, check to see if we might need an app for
+    // For every driver that we are aware of at this time, check to see if we might
+    // need an app for
     // any of them
     for (var driver : expectedDrivers) {
       final var expectedDriverCaps = ContextManager.INSTANCE.lookupDriver(driver).evaluate();
       if (!expectedDriverCaps.getApplauseOptions().isMobileNative()) {
         continue;
       }
-      if (!expectedDriverCaps.getCapabilityNames().contains("app")) {
+
+      // If the app is not specified in the capabilities or in the environment
+      // configuration,
+      // we need to auto-detect the build and perform the app push if necessary
+      if (Strings.isNullOrEmpty(expectedDriverCaps.getApp())
+          && Strings.isNullOrEmpty(EnvironmentConfigurationManager.INSTANCE.get().app())) {
         ApplauseAppPushHelper.autoDetectBuildIfNecessary();
         ApplauseAppPushHelper.performApplicationPushIfNecessary();
       }

--- a/auto-sdk-java-framework/src/main/java/com/applause/auto/framework/selenium/EnhancedCapabilities.java
+++ b/auto-sdk-java-framework/src/main/java/com/applause/auto/framework/selenium/EnhancedCapabilities.java
@@ -140,6 +140,13 @@ public class EnhancedCapabilities implements Capabilities {
                 AbstractMap.SimpleImmutableEntry::getValue));
   }
 
+  public String getApp() {
+    return Optional.ofNullable(resolvedCaps)
+        .map(caps -> caps.getCapability("appium:app"))
+        .map(Object::toString)
+        .orElse(null);
+  }
+
   @Override
   public Object getCapability(final @NonNull String capabilityName) {
     return resolvedCaps.getCapability(capabilityName);

--- a/auto-sdk-java-integrations/src/test/java/com/applause/auto/helpers/AutoBuildHelperTest.java
+++ b/auto-sdk-java-integrations/src/test/java/com/applause/auto/helpers/AutoBuildHelperTest.java
@@ -24,8 +24,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.applause.auto.config.ApplauseEnvironmentConfigurationManager;
-import com.applause.auto.config.EnvironmentConfigurationManager;
-import com.applause.auto.framework.selenium.EnhancedCapabilities;
 import com.applause.auto.util.applausepublicapi.ApplausePublicApi;
 import com.applause.auto.util.applausepublicapi.api.BuildApi;
 import com.applause.auto.util.applausepublicapi.dto.AttachmentWithHashesDto;
@@ -39,35 +37,6 @@ import org.testng.annotations.Test;
 import retrofit2.Response;
 
 public class AutoBuildHelperTest {
-
-  @Test
-  public void testGetApp() {
-    // test null input with no EnvironmentConfig
-    Object actualValue = AutoBuildHelper.getApp(null);
-    Assert.assertNull(actualValue, "null appCaps, return null from Bean");
-
-    // test non-null input with no EnvironmentConfig.override
-    EnhancedCapabilities caps = mock(EnhancedCapabilities.class);
-    when(caps.getCapability("app")).thenReturn("app-from-cfg1");
-    Assert.assertEquals(
-        "app-from-cfg1",
-        AutoBuildHelper.getApp(caps),
-        "with appCaps, return 'app-from-cfg1' from Bean");
-
-    // test null input with EnvironmentConfig.override
-    EnvironmentConfigurationManager.INSTANCE.override(Map.of("app", "app-from-cfg2"));
-    actualValue = AutoBuildHelper.getApp(null);
-    Assert.assertEquals(
-        "app-from-cfg2", actualValue, "null appCaps, return 'app-from-cfg2' from Bean");
-
-    // Finally, ensure we prioritize input over EnvironmentConfig.override
-    when(caps.getCapability("app")).thenReturn("preferred-app");
-    EnvironmentConfigurationManager.INSTANCE.override(Map.of("app", "app-from-cfg3"));
-    Assert.assertEquals(
-        "preferred-app",
-        AutoBuildHelper.getApp(caps),
-        "with appCaps, return 'preferred-app' from Bean");
-  }
 
   @Test
   public void testGetAllBuilds() {

--- a/auto-sdk-java-testng/src/main/java/com/applause/auto/testng/listeners/FrameworkConfigurationListener.java
+++ b/auto-sdk-java-testng/src/main/java/com/applause/auto/testng/listeners/FrameworkConfigurationListener.java
@@ -30,6 +30,7 @@ import com.applause.auto.logging.LogOutputSingleton;
 import com.applause.auto.logging.ResultPropertyMap;
 import com.applause.auto.templates.TemplateManager;
 import com.applause.auto.testng.TestNgContextUtils;
+import com.google.api.client.util.Strings;
 import com.google.common.collect.Sets;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -151,7 +152,11 @@ public class FrameworkConfigurationListener implements ISuiteListener {
       if (!expectedDriverCaps.getApplauseOptions().isMobileNative()) {
         continue;
       }
-      if (!expectedDriverCaps.getCapabilityNames().contains("app")) {
+
+      // If the app is not specified in the capabilities or in the environment configuration,
+      // we need to auto-detect the build and perform the app push if necessary
+      if (Strings.isNullOrEmpty(expectedDriverCaps.getApp())
+          && Strings.isNullOrEmpty(EnvironmentConfigurationManager.INSTANCE.get().app())) {
         ApplauseAppPushHelper.autoDetectBuildIfNecessary();
         ApplauseAppPushHelper.performApplicationPushIfNecessary();
         break;


### PR DESCRIPTION
### What changed?
After the appium upgrade, the app property needs to be prefixed with appium:. As a result, we need to update out app autodetection/push logic to look for the appium:app property
