### PR TITLE
Fix LazyWebElement exists() throwing error when element is not present

### DIFF
--- a/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/base/BaseComponent.java
+++ b/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/base/BaseComponent.java
@@ -288,12 +288,7 @@ public abstract class BaseComponent implements UIElement {
           "Cannot check existence of component [%s] with no underlying element"
               .formatted(this.getClass().getSimpleName()));
     }
-    boolean exists = true;
-    try {
-      this.underlying.isEnabled();
-    } catch (NoSuchElementException | TimeoutException | StaleElementReferenceException e) {
-      exists = false;
-    }
+    boolean exists = this.underlying.exists();
 
     logger.debug("{} {}.", this.getClass().getSimpleName(), exists ? "exists" : "does not exist");
     return exists;

--- a/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/base/BaseElement.java
+++ b/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/base/BaseElement.java
@@ -275,12 +275,7 @@ public abstract class BaseElement implements UIElement {
 
   @Override
   public boolean exists() {
-    boolean exists = true;
-    try {
-      this.underlying.isEnabled();
-    } catch (NoSuchElementException | TimeoutException | StaleElementReferenceException e) {
-      exists = false;
-    }
+    boolean exists = this.underlying.exists();
 
     logger.debug("{} {}.", this.getClass().getSimpleName(), exists ? "exists" : "does not exist");
     return exists;

--- a/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/factory/LazyWebElement.java
+++ b/auto-sdk-java-page-object/src/main/java/com/applause/auto/pageobjectmodel/factory/LazyWebElement.java
@@ -556,11 +556,21 @@ public class LazyWebElement implements WebElement, UIElement {
     return this.pollingInterval;
   }
 
+  /**
+   * Checks if the element exists in the DOM. This is done by calling isEnabled() and catching any
+   * exceptions that indicate the element isn't present.
+   */
   @Override
-  @SuppressWarnings(
-      "PMD.LambdaCanBeMethodReference") // Lambda required to defer null check for lazy-loading
   public boolean exists() {
-    return runLazily(() -> this.underlying.isEnabled());
+    boolean exists = true;
+    try {
+      this.isEnabled();
+    } catch (NoSuchElementException | TimeoutException | StaleElementReferenceException e) {
+      exists = false;
+    }
+
+    logger.debug("{} {}.", this.getClass().getSimpleName(), exists ? "exists" : "does not exist");
+    return exists;
   }
 
   @Override

--- a/auto-sdk-java-page-object/src/test/java/com/applause/auto/pageobjectmodel/factory/LazyWebElementTest.java
+++ b/auto-sdk-java-page-object/src/test/java/com/applause/auto/pageobjectmodel/factory/LazyWebElementTest.java
@@ -92,6 +92,8 @@ public class LazyWebElementTest {
     when(mockDriver.findElements(By.id("top-grand-child"))).thenReturn(List.of(grandChildMock));
     when(mockDriver.findElement(By.id("%s"))).thenThrow(new NoSuchElementException(""));
     when(mockDriver.findElements(By.id("%s"))).thenThrow(new NoSuchElementException(""));
+    when(mockDriver.findElement(By.id("no-such-element")))
+        .thenThrow(new NoSuchElementException(""));
 
     final var jQueryMock = mock(WebElement.class);
     when(jQueryMock.getAttribute("id")).thenReturn("fake-id");
@@ -463,5 +465,22 @@ public class LazyWebElementTest {
 
     logger.info("STEP 3: Get an attribute from the element, finding it on the page.");
     assertEquals(element.getAttribute("id"), "fake-id");
+  }
+
+  /**
+   * Validate that the exists() function does not throw a no such element exception when the element
+   * is not found, and instead returns false.
+   */
+  @Test
+  public void testExistsNoSuchElement() {
+    logger.info("STEP 1: Create a Locator for a non-existent element.");
+    Locator locator = new Locator(LocatedBy.id("no-such-element"), this.context.getPlatform());
+
+    logger.info("STEP 2: Create a LazyWebElement with the Locator.");
+    LazyWebElement lazy = new LazyWebElement(locator, this.context);
+
+    logger.info(
+        "STEP 3: Call exists() on the LazyWebElement, which should return false without throwing an exception.");
+    assertFalse(lazy.exists());
   }
 }


### PR DESCRIPTION
### What changed?
Fix LazyWebElement exists() throwing error when element is not present

This also fixes the usage of scrollToElement(), which relies on the exists() function.
